### PR TITLE
Fix compatibility with latest version of rasterio

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.2 (unreleased)
 ----------------
 
-- No changes yet
+- Fixed compatibility with rasterio 1.x.
 
 0.1 (2017-08-23)
 ----------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,16 +12,16 @@ environment:
                         # to the matrix section.
 
       CONDA_CHANNELS: "glueviz"
-      CONDA_DEPENDENCIES: "glue-core rasterio pyproj nomkl"
+      CONDA_DEPENDENCIES: "glue-core rasterio pyproj"
 
   matrix:
 
         # We have to pin PyQt5 to a specific build with Python 2.7 to avoid
         # segmentation faults with pyqt=5.6.0=py27_2
       - PYTHON_VERSION: "2.7"
-        CONDA_DEPENDENCIES: "glue-core rasterio pyproj nomkl pyqt=5.6.0=py27h6e61f57_6"
+        CONDA_DEPENDENCIES: "glue-core rasterio pyproj pyqt=5.6.0=py27h6e61f57_6"
       - PYTHON_VERSION: "2.7"
-        CONDA_DEPENDENCIES: "glue-core rasterio pyproj nomkl pyqt=5.6.0=py27h6e61f57_6"
+        CONDA_DEPENDENCIES: "glue-core rasterio pyproj pyqt=5.6.0=py27h6e61f57_6"
         CONDA_CHANNELS: "glueviz/label/dev"
 
       - PYTHON_VERSION: "3.6"

--- a/glue_geospatial/coordinates.py
+++ b/glue_geospatial/coordinates.py
@@ -71,14 +71,14 @@ class GeospatialLonLatCoordinates(Coordinates):
             if affine is not None or crs_dict is not None:
                 raise ValueError("Either raster_reader or affine/crs_dict should be given")
 
-            affine = raster_reader.affine
+            affine = raster_reader.transform
 
             if flipud:
                 M = raster_reader.shape[0]
                 affine = Affine(affine.a, -affine.b, affine.c + affine.b * M,
                                 affine.d, -affine.e, affine.f + affine.e * M)
             else:
-                affine = raster_reader.affine
+                affine = raster_reader.transform
 
             crs_dict = raster_reader.crs.to_dict()
 


### PR DESCRIPTION
I think this should also be compatible with older versions, as ``affine`` was always an alias.