### PR TITLE
Fix continuous integration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.4 (2020-02-02)
+----------------
+
+- Fixed compatibility with the latest version of glue-core. [#21]
+
 0.3 (2019-07-08)
 ----------------
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,12 +26,13 @@ jobs:
     - linux: py36-test
     - linux: py37-test
     - linux: py38-test-dev
-    # - linux: py39-test-dev
+    - linux: py39-test-dev
 
     - macos: py36-test
     - macos: py37-test
     - macos: py38-test-dev
-    # - macos: py39-test-dev
+    - macos: py39-test-dev
 
     # We don't test on Windows since there are no rasterio wheels
-    # available there.
+    # available there, but there's no reason in principle why the
+    # plugin code here should be platform dependent.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,16 +23,15 @@ jobs:
       libraries: {}
       coverage: 'false'
 
-    - linux: py36-test-dev
-    - linux: py37-test-dev
-    # - linux: py38-test-dev
+    - linux: py36-test
+    - linux: py37-test
+    - linux: py38-test-dev
+    # - linux: py39-test-dev
 
-    - macos: py36-test-dev
-    - macos: py37-test-dev
-    # - macos: py38-test-dev
+    - macos: py36-test
+    - macos: py37-test
+    - macos: py38-test-dev
+    # - macos: py39-test-dev
 
-    # We add -win so that rasterio and GDAL are downloaded from
-    # https://www.lfd.uci.edu/~gohlke/pythonlibs/
-    - windows: py36-test-dev-win
-    - windows: py37-test-dev-win
-    # - windows: py38-test-dev
+    # We don't test on Windows since there are no rasterio wheels
+    # available there.

--- a/glue_geospatial/tests/test_basic.py
+++ b/glue_geospatial/tests/test_basic.py
@@ -15,5 +15,6 @@ def test_geospatial(tmpdir):
     data = geospatial_reader(os.path.join(DATA, 'simplegeo.tif'))
     assert data.shape == (18, 24)
 
+
     assert_allclose(data.coords.pixel_to_world_values(9, 12),
-                    (-3.971667,  2.981667))
+                    (-3.9716666666666676, 2.9816666666666665))

--- a/glue_geospatial/tests/test_basic.py
+++ b/glue_geospatial/tests/test_basic.py
@@ -15,6 +15,5 @@ def test_geospatial(tmpdir):
     data = geospatial_reader(os.path.join(DATA, 'simplegeo.tif'))
     assert data.shape == (18, 24)
 
-
     assert_allclose(data.coords.pixel_to_world_values(9, 12),
                     (-3.9716666666666676, 2.9816666666666665))

--- a/glue_geospatial/tests/test_basic.py
+++ b/glue_geospatial/tests/test_basic.py
@@ -16,4 +16,4 @@ def test_geospatial(tmpdir):
     assert data.shape == (18, 24)
 
     assert_allclose(data.coords.pixel_to_world_values(9, 12),
-                    (132.440262367208, 170.83691591484046))
+                    (-3.971667,  2.981667))

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,7 @@ setup_requires = setuptools_scm
 install_requires =
     glue-core>=0.11
     rasterio>=1.0
-    # Recent versions of pyproj have an issue
-    # https://github.com/pyproj4/pyproj/issues/520
-    pyproj<2.3
+    pyproj>=2.3
     affine
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}-test{-devdeps}
+envlist = py{36,37,38,39}-test{-devdeps}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -11,12 +11,6 @@ changedir =
     test: .tmp/{envname}
 deps =
     dev: glue-core @ git+https://github.com/glue-viz/glue
-    py36-win: https://download.lfd.uci.edu/pythonlibs/q4hpdf1k/rasterio-1.1.2-cp36-cp36m-win_amd64.whl
-    py36-win: https://download.lfd.uci.edu/pythonlibs/q4hpdf1k/GDAL-3.0.3-cp36-cp36m-win_amd64.whl
-    py37-win: https://download.lfd.uci.edu/pythonlibs/q4hpdf1k/rasterio-1.1.2-cp37-cp37m-win_amd64.whl
-    py37-win: https://download.lfd.uci.edu/pythonlibs/q4hpdf1k/GDAL-3.0.3-cp37-cp37m-win_amd64.whl
-    py38-win: https://download.lfd.uci.edu/pythonlibs/q4hpdf1k/rasterio-1.1.2-cp38-cp38m-win_amd64.whl
-    py38-win: https://download.lfd.uci.edu/pythonlibs/q4hpdf1k/GDAL-3.0.3-cp38-cp38m-win_amd64.whl
 extras =
     test: test,qt
 commands =
@@ -27,4 +21,4 @@ commands =
 deps = flake8
 skip_install = true
 commands =
-    flake8 --max-line-length=100 glue_vispy_viewers
+    flake8 --max-line-length=100 glue_geospatial


### PR DESCRIPTION
Drop Windows testing due to lack of Windows wheels and add Python 3.8 and 3.9 to the CI configuration